### PR TITLE
allow typeparams in combination with baseclass

### DIFF
--- a/src/SimpleStructs.jl
+++ b/src/SimpleStructs.jl
@@ -95,24 +95,27 @@ function _defstruct_impl(is_immutable, name, fields)
   type_param_names = Array(Symbol, 0)
 
   if isa(name, Symbol)
-    name       = name
     super_name = :Any
+    name       = name
   elseif isa(name, Expr) && name.head == :curly
     type_param_names = map(_type_param_name, name.args[2:end]) # :T
-    name       = name
     super_name = :Any
+    name       = name
   else
     @assert(isa(name, Expr) && name.head == :comparison && length(name.args) == 3 && name.args[2] == :(<:),
             "name must be of form 'Name <: SuperType'")
-    @assert(isa(name.args[1], Symbol) && isa(name.args[3], Symbol))
+    #@assert(isa(name.args[1], Symbol) && isa(name.args[3], Symbol))
+    if isa(name.args[1], Expr) && name.args[1].head == :curly
+        type_param_names = map(_type_param_name, name.args[1].args[2:end]) # :T
+    end
     super_name = name.args[3]
     name       = name.args[1]
   end
 
   field_defs     = Array(Expr, length(fields))        # :(field2 :: Int)
-  field_names    = Array(Any, length(fields))        # :field2
+  field_names    = Array(Any, length(fields))         # :field2
   field_defaults = Array(Expr, length(fields))        # :(field2 = 0)
-  field_types    = Array(Any, length(fields))        # Int
+  field_types    = Array(Any, length(fields))         # Int
   field_asserts  = Array(Expr, length(fields))        # :(field2 >= 0)
   required_field = Symbol[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,5 +70,24 @@ struct4 = Struct4()
 )
 @test_throws MethodError struct5 = Struct5()
 struct5 = Struct5(field = [1,2,3])
+@test typeof(struct5) <: Struct5{Int, Float64}
 @test typeof(struct5.field) <: Vector{Int}
+@test struct5.field == [1,2,3]
 @test typeof(struct5.field2) <: Vector{Float64}
+@test struct5.field2 == [0.,0,0,0,0]
+
+################################################################################
+# type parameters with base class
+################################################################################
+@defimmutable Struct6{R<:Real, T<:Real} <: AbstractVector{R} (
+  field  :: Vector{R},
+  field2 :: Vector{T} = zeros(5),
+)
+@test_throws MethodError struct6 = Struct6()
+struct6 = Struct6(field = [-1,2,3], field2 = [0., 1.])
+@test typeof(struct6) <: Struct6{Int, Float64}
+@test typeof(struct6) <: AbstractVector{Int}
+@test typeof(struct6.field) <: Vector{Int}
+@test struct6.field == [-1,2,3]
+@test typeof(struct6.field2) <: Vector{Float64}
+@test struct6.field2 == [0.,1]


### PR DESCRIPTION
Follow up to [PR 1](https://github.com/pluskid/SimpleStructs.jl/pull/1)

now this works as well:

``` Julia
@defimmutable Struct6{R<:Real, T<:Real} <: AbstractVector{R} (
  field  :: Vector{R},
  field2 :: Vector{T} = zeros(5),
)
```

```
:($(Expr(:escape, quote 
    immutable Struct6{R <: Real,T <: Real} <: AbstractVector{R}
        begin 
            field::Vector{R}
            field2::Vector{T}
        end
    end
    Struct6{R <: Real,T <: Real}(; field::Vector{R}=SimpleStructs.__Undefined(),field2::Vector{T}=zeros(5)) = begin 
            @assert !(isa(field,SimpleStructs.__Undefined)) "value for " * string(field) * " is required"
            field = convert(Vector{R},field)
            field2 = convert(Vector{T},field2)
            Struct6{R,T}(field,field2)
        end
end)))
```
